### PR TITLE
Tm patch

### DIFF
--- a/lib/app.rb
+++ b/lib/app.rb
@@ -17,7 +17,7 @@ end
 
 get '/ping' do
   begin
-  	verify_peer_value = (ENV["RABBITMQ_SKIP_SSL"] != "1")
+		verify_peer_value = (ENV["RABBITMQ_SKIP_SSL"] != "1")
     c = Bunny.new(rabbitmq_url, :verify_peer => verify_peer_value)
     c.start
     c.create_channel

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -17,7 +17,7 @@ end
 
 get '/ping' do
   begin
-		verify_peer_value = (ENV["RABBITMQ_SKIP_SSL"] != "1")
+    verify_peer_value = (ENV["RABBITMQ_SKIP_SSL"] != "1")
     c = Bunny.new(rabbitmq_url, :verify_peer => verify_peer_value)
     c.start
     c.create_channel
@@ -123,8 +123,8 @@ end
 def client
   unless $client
     begin
-			verify_peer_value = (ENV["RABBITMQ_SKIP_SSL"] != "1")
-			c = Bunny.new(rabbitmq_url, :verify_peer => verify_peer_value)
+      verify_peer_value = (ENV["RABBITMQ_SKIP_SSL"] != "1")
+      c = Bunny.new(rabbitmq_url, :verify_peer => verify_peer_value)
       c.start
       $client = c.create_channel
     rescue Exception

--- a/lib/app.rb
+++ b/lib/app.rb
@@ -17,10 +17,10 @@ end
 
 get '/ping' do
   begin
-    c = Bunny.new(rabbitmq_url)
+  	verify_peer_value = (ENV["RABBITMQ_SKIP_SSL"] != "1")
+    c = Bunny.new(rabbitmq_url, :verify_peer => verify_peer_value)
     c.start
     c.create_channel
-
     status 200
     body 'OK'
 
@@ -123,7 +123,8 @@ end
 def client
   unless $client
     begin
-      c = Bunny.new(rabbitmq_url)
+			verify_peer_value = (ENV["RABBITMQ_SKIP_SSL"] != "1")
+			c = Bunny.new(rabbitmq_url, :verify_peer => verify_peer_value)
       c.start
       $client = c.create_channel
     rescue Exception


### PR DESCRIPTION
We can now set an environment variable in order to skip SSL validation for creation of a new RabbitMQ client.
